### PR TITLE
UDP refactor

### DIFF
--- a/client.py
+++ b/client.py
@@ -50,6 +50,22 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def tcp_listener(
+    tcp_socket: socket.socket,
+    client_instance: ClientInstance,
+) -> None:
+    """
+    Waits for messages from the server and then processes them
+
+    :param socket: the connection to the server
+    :param client_instance: the instance of the client
+    :return:
+    """
+    while True:  # TODO kill thread when client quits by checking flag
+        input_message = cast(message.ServerMessage, network.recv(tcp_socket))
+        client_instance.process_input_message(input_message)
+
+
 def udp_listener(
     udp_socket: socket.socket,
     client_instance: ClientInstance,
@@ -117,8 +133,10 @@ def run_client(args: argparse.Namespace) -> None:
         args.sensitivity,
     )
 
-    t = Thread(target=udp_listener, args=(udp_socket, client_instance))
+    t = Thread(target=tcp_listener, args=(tcp_socket, client_instance))
     t.start()
+    u = Thread(target=udp_listener, args=(udp_socket, client_instance))
+    u.start()
 
     while client_instance.step():
         pass

--- a/client.py
+++ b/client.py
@@ -87,7 +87,7 @@ def initialize_network(
         udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         network.sendto(
             udp_socket,
-            (ip_address, server_join_message.udp_port),
+            (ip_address, port),
             message.UDPSetMessage(server_join_message.player_id),
         )
 
@@ -110,7 +110,7 @@ def run_client(args: argparse.Namespace) -> None:
     client_instance = ClientInstance(
         tcp_socket,
         udp_socket,
-        (args.ip_address, server_join_message.udp_port),
+        (args.ip_address, args.port),
         server_join_message,
         args.fullscreen,
         args.frame_rate,

--- a/client.py
+++ b/client.py
@@ -50,8 +50,8 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def server_listener(
-    socket: socket.socket,
+def udp_listener(
+    udp_socket: socket.socket,
     client_instance: ClientInstance,
 ) -> None:
     """
@@ -62,13 +62,14 @@ def server_listener(
     :return:
     """
     while True:  # TODO kill thread when client quits by checking flag
-        input_message = cast(message.ServerMessage, network.recv(socket))
+        input_message = cast(message.ServerMessage, network.recvfrom(udp_socket)[0])
         client_instance.process_input_message(input_message)
 
 
 def initialize_network(
-    ip_address: str, port: int
-) -> tuple[socket.socket, ServerJoinMessage]:
+    ip_address: str,
+    port: int,
+) -> tuple[socket.socket, ServerJoinMessage, socket.socket]:
     """
     Makes an initial connection with the server, returns the socket it is connected through
     and the join message from the server
@@ -76,13 +77,21 @@ def initialize_network(
     :param ip_address: the ip address of the server
     :param port: the port of the server
     """
-    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    server_socket.connect((ip_address, port))
+    tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    tcp_socket.connect((ip_address, port))
+    server_join_message = network.recv(tcp_socket)
 
-    server_join_message = network.recv(server_socket)
     if type(server_join_message) is message.ServerJoinMessage:
         print(f"You are player {server_join_message.player_id}")
-        return server_socket, server_join_message
+
+        udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        network.sendto(
+            udp_socket,
+            (ip_address, server_join_message.udp_port),
+            message.UDPSetMessage(server_join_message.player_id),
+        )
+
+        return tcp_socket, server_join_message, udp_socket
     else:
         raise message.UnknownMessageTypeError
 
@@ -93,22 +102,26 @@ def run_client(args: argparse.Namespace) -> None:
 
     :param args: command line arguments parsed by argparse
     """
-    server_socket, server_join_message = initialize_network(args.ip_address, args.port)
+    tcp_socket, server_join_message, udp_socket = initialize_network(
+        args.ip_address,
+        args.port,
+    )
 
     client_instance = ClientInstance(
-        server_socket,
+        tcp_socket,
+        udp_socket,
+        (args.ip_address, server_join_message.udp_port),
         server_join_message,
         args.fullscreen,
         args.frame_rate,
         args.sensitivity,
     )
 
-    t = Thread(target=server_listener, args=(server_socket, client_instance))
+    t = Thread(target=udp_listener, args=(udp_socket, client_instance))
     t.start()
 
-    running = True
-    while running:
-        running = client_instance.step()
+    while client_instance.step():
+        pass
 
     pygame.quit()
 

--- a/client_instance.py
+++ b/client_instance.py
@@ -19,14 +19,16 @@ import socket
 import map_loading
 import math
 from chatbox import ChatBox
-from typing import cast
+from typing import cast, Any
 import simulation_object.constants
 
 
 class ClientInstance:
     def __init__(
         self,
-        socket: socket.socket,
+        tcp_socket: socket.socket,
+        udp_socket: socket.socket,
+        server_addr: tuple[Any, Any],
         server_join_message: ServerJoinMessage,
         fullscreen: bool,
         frame_rate: int,
@@ -34,7 +36,9 @@ class ClientInstance:
     ):
         self._setup_pygame(fullscreen)
 
-        self.socket = socket
+        self.tcp_socket = tcp_socket
+        self.udp_socket = udp_socket
+        self.server_addr = server_addr
         self.player_id = server_join_message.player_id
         self.map_name = server_join_message.map_name
         self.frame_rate = frame_rate
@@ -135,7 +139,7 @@ class ClientInstance:
                         text_message = PlayerTextMessage(
                             player_id=self.player_id, text=text
                         )
-                        network.send(self.socket, text_message)
+                        network.send(self.tcp_socket, text_message)
 
                 elif event.key == pygame.K_ESCAPE and self.user_typing:
                     self.user_typing = False
@@ -179,7 +183,7 @@ class ClientInstance:
             map_vote=self.map_vote,
         )
 
-        network.send(self.socket, output_message)
+        network.sendto(self.udp_socket, self.server_addr, output_message)
 
     def process_input_message(self, input_message: ServerMessage) -> None:
         """

--- a/commands.py
+++ b/commands.py
@@ -71,7 +71,7 @@ class CommandRunner:
         text_message = PlayerTextMessage(
             player_id=self.client_instance.player_id, text=f"readied up"
         )
-        network.send(self.client_instance.socket, text_message)
+        network.send(self.client_instance.tcp_socket, text_message)
 
     def map_vote(self, args: list[str]) -> None:
         map_vote = args[0]
@@ -80,7 +80,7 @@ class CommandRunner:
         text_message = PlayerTextMessage(
             player_id=self.client_instance.player_id, text=f"voted for map {map_vote}"
         )
-        network.send(self.client_instance.socket, text_message)
+        network.send(self.client_instance.tcp_socket, text_message)
 
     def quit(self, _: Any) -> None:
         self.client_instance.quit()
@@ -88,4 +88,4 @@ class CommandRunner:
         text_message = PlayerTextMessage(
             player_id=self.client_instance.player_id, text=f"quit the game"
         )
-        network.send(self.client_instance.socket, text_message)
+        network.send(self.client_instance.tcp_socket, text_message)

--- a/comms/message.py
+++ b/comms/message.py
@@ -57,6 +57,12 @@ class PlayerTextMessage(ClientMessage):
 class ServerJoinMessage(ServerMessage):
     player_id: UUID
     map_name: str
+    udp_port: int
+
+
+@dataclass
+class UDPSetMessage(ServerMessage):
+    player_id: UUID
 
 
 @dataclass

--- a/comms/message.py
+++ b/comms/message.py
@@ -57,7 +57,6 @@ class PlayerTextMessage(ClientMessage):
 class ServerJoinMessage(ServerMessage):
     player_id: UUID
     map_name: str
-    udp_port: int
 
 
 @dataclass

--- a/comms/network.py
+++ b/comms/network.py
@@ -15,7 +15,6 @@ def _recv_exactly(socket: socket.socket, num_bytes: int) -> bytes:
 
 
 def send(socket: socket.socket, message: Message) -> None:
-    # print("sending:", message)
     bytes = pickle.dumps(message)
     num_message_bytes = len(bytes).to_bytes(4, "little")
 
@@ -23,7 +22,6 @@ def send(socket: socket.socket, message: Message) -> None:
 
 
 def sendto(socket: socket.socket, addr: tuple[Any, Any], message: Message) -> None:
-    # print("sending:", message, "to:", addr)
     bytes = pickle.dumps(message)
     socket.sendto(bytes, addr)
 
@@ -34,12 +32,10 @@ def recv(socket: socket.socket) -> Message:
 
     message_as_bytes = _recv_exactly(socket, num_message_bytes)
     message = pickle.loads(message_as_bytes)
-    # print("received:", message)
     return message
 
 
 def recvfrom(socket: socket.socket) -> tuple[Message, tuple[Any, Any]]:
     bytes, addr = socket.recvfrom(65507)
     message = pickle.loads(bytes)
-    # print("received:", message, "from:", addr)
     return message, addr

--- a/comms/network.py
+++ b/comms/network.py
@@ -1,3 +1,4 @@
+from typing import Any
 from comms.message import Message
 import pickle
 import socket
@@ -14,10 +15,17 @@ def _recv_exactly(socket: socket.socket, num_bytes: int) -> bytes:
 
 
 def send(socket: socket.socket, message: Message) -> None:
+    # print("sending:", message)
     bytes = pickle.dumps(message)
     num_message_bytes = len(bytes).to_bytes(4, "little")
 
     socket.sendall(num_message_bytes + bytes)
+
+
+def sendto(socket: socket.socket, addr: tuple[Any, Any], message: Message) -> None:
+    # print("sending:", message, "to:", addr)
+    bytes = pickle.dumps(message)
+    socket.sendto(bytes, addr)
 
 
 def recv(socket: socket.socket) -> Message:
@@ -25,4 +33,13 @@ def recv(socket: socket.socket) -> Message:
     num_message_bytes = int.from_bytes(num_message_bytes_as_bytes, "little")
 
     message_as_bytes = _recv_exactly(socket, num_message_bytes)
-    return pickle.loads(message_as_bytes)
+    message = pickle.loads(message_as_bytes)
+    # print("received:", message)
+    return message
+
+
+def recvfrom(socket: socket.socket) -> tuple[Message, tuple[Any, Any]]:
+    bytes, addr = socket.recvfrom(65507)
+    message = pickle.loads(bytes)
+    # print("received:", message, "from:", addr)
+    return message, addr

--- a/server.py
+++ b/server.py
@@ -12,20 +12,39 @@ from simulation import Simulation
 import global_simulation
 
 
-def listener(server_socket: socket.socket, state_queue: Queue[message.Message]) -> None:
+def tcp_listener(
+    tcp_socket: socket.socket, udp_port: int, input_messages: Queue[message.Message]
+) -> None:
     while True:
-        client_socket, addr = server_socket.accept()
-        player_id = global_simulation.SIMULATION.add_player(client_socket)
+        client_socket, addr = tcp_socket.accept()
+        player_id = global_simulation.SIMULATION.add_player(client_socket, addr)
         network.send(
             client_socket,
             message.ServerJoinMessage(
-                player_id=player_id, map_name=global_simulation.SIMULATION.map_name
+                player_id=player_id,
+                map_name=global_simulation.SIMULATION.map_name,
+                udp_port=udp_port,
             ),
         )
         print(f"Accepted connection from {addr}")
 
-        t = Thread(target=client_listener, args=(client_socket, state_queue))
+        t = Thread(target=client_listener, args=(client_socket, input_messages))
         t.start()
+
+
+def udp_listener(
+    udp_socket: socket.socket, input_messages: Queue[message.Message]
+) -> None:
+    while True:
+        msg, addr = network.recvfrom(udp_socket)
+        if type(msg) == message.UDPSetMessage:
+            if msg.player_id in global_simulation.SIMULATION.players:
+                # TODO: validate that the player is who they say they are
+                global_simulation.SIMULATION.players[msg.player_id].set_udp(addr)
+            else:
+                print(f"unknown player connecting via udp: {addr}")
+        else:
+            input_messages.put(msg)
 
 
 def client_listener(
@@ -33,19 +52,23 @@ def client_listener(
 ) -> None:
     while True:
         try:
-            input_messages.put(network.recv(socket))
+            message = network.recv(socket)
+            input_messages.put(message)
         except ConnectionResetError:
             exit()
 
 
-def server_messager(output_messages: Queue[message.Message]) -> None:
+def server_messager(
+    udp_socket: socket.socket, output_messages: Queue[message.Message]
+) -> None:
     while True:
         if not output_messages.empty():
             message = output_messages.get()
             players = global_simulation.SIMULATION.get_players()
             for player in players:
                 try:
-                    network.send(player.socket, message)
+                    if player.udp_addr is not None:
+                        network.sendto(udp_socket, player.udp_addr, message)
                 except BrokenPipeError:
                     print(f"Player {player} forcibly disconnected!")
                     global_simulation.SIMULATION.remove_player(player)
@@ -72,15 +95,17 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def initialize_socket() -> socket.socket:
-    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+def initialize_sockets(args: argparse.Namespace) -> tuple[socket.socket, socket.socket]:
+    tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     ip_address = "localhost" if args.local else ""
 
-    server_socket.bind((ip_address, args.port))
-    server_socket.listen()
+    tcp_socket.bind((ip_address, args.port))
+    tcp_socket.listen()
+    udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    udp_socket.bind((ip_address, args.port))
     print(f"Server started on {(ip_address, args.port)}")
 
-    return server_socket
+    return (tcp_socket, udp_socket)
 
 
 def load_requested_map(
@@ -112,20 +137,33 @@ def run_server(args: argparse.Namespace) -> None:
 
     global_simulation.SIMULATION = Simulation(args.map, input_messages, output_messages)
 
-    server_socket = initialize_socket()
+    tcp_socket, udp_socket = initialize_sockets(args)
 
     tsa_t = Thread(
-        target=listener,
+        target=tcp_listener,
         args=(
-            server_socket,
+            tcp_socket,
+            args.port,
             input_messages,
         ),
     )
     tsa_t.start()
 
+    usa_t = Thread(
+        target=udp_listener,
+        args=(
+            udp_socket,
+            input_messages,
+        ),
+    )
+    usa_t.start()
+
     gss_t = Thread(
         target=server_messager,
-        args=(output_messages,),
+        args=(
+            udp_socket,
+            output_messages,
+        ),
     )
     gss_t.start()
 

--- a/server.py
+++ b/server.py
@@ -13,7 +13,7 @@ import global_simulation
 
 
 def tcp_listener(
-    tcp_socket: socket.socket, udp_port: int, input_messages: Queue[message.Message]
+    tcp_socket: socket.socket, input_messages: Queue[message.Message]
 ) -> None:
     while True:
         client_socket, addr = tcp_socket.accept()
@@ -23,7 +23,6 @@ def tcp_listener(
             message.ServerJoinMessage(
                 player_id=player_id,
                 map_name=global_simulation.SIMULATION.map_name,
-                udp_port=udp_port,
             ),
         )
         print(f"Accepted connection from {addr}")
@@ -143,7 +142,6 @@ def run_server(args: argparse.Namespace) -> None:
         target=tcp_listener,
         args=(
             tcp_socket,
-            args.port,
             input_messages,
         ),
     )

--- a/simulation.py
+++ b/simulation.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from queue import Queue
-from typing import cast
+from typing import cast, Any
 
 from comms.message import SimulationStateMessage
 from map_loading import BoundingWall
@@ -108,7 +108,9 @@ class Simulation:
             raise Exception("Object {object} not found while deregistering!")
         del target_dict[object.uuid]  # type: ignore
 
-    def add_player(self, client_socket: socket.socket = None) -> UUID:
+    def add_player(
+        self, client_socket: socket.socket = None, remote_addr: tuple[Any, Any] = None
+    ) -> UUID:
         """
         Add a player to the simulation, client_socket is optional for when
         you are running a simulation locally and you don't need to send out messages
@@ -117,10 +119,7 @@ class Simulation:
         :return:
         """
         spawn = random.choice(self.map.spawns)
-        player = Player(
-            spawn.position,
-            client_socket,
-        )
+        player = Player(spawn.position, client_socket, remote_addr)
         return player.uuid
 
     def remove_player(self, player: SimulationObject) -> None:

--- a/simulation_object/player.py
+++ b/simulation_object/player.py
@@ -13,13 +13,19 @@ from weapons.rocket_launcher import RocketLauncher
 from simulation_object.simulation_object import SimulationObject
 import simulation_object.constants
 from abc import ABC
+from typing import Any
 
 from network_object.player import PlayerNetworkObject
 from weapons.shotgun import ShotGun
 
 
 class Player(SimulationObject, body.ConstantAccelerationBody):
-    def __init__(self, start_position: tuple[float, float], socket: socket.socket):
+    def __init__(
+        self,
+        start_position: pygame.math.Vector2,
+        socket: socket.socket,
+        client_addr: tuple[Any, Any],
+    ):
         super().__init__()
         super(ABC, self).__init__(
             start_position, game_engine_constants.PLAYER_RADIUS, 0.05, 1500
@@ -28,6 +34,8 @@ class Player(SimulationObject, body.ConstantAccelerationBody):
         self.time_of_death = None
 
         self.socket = socket
+        self.tcp_addr = client_addr
+        self.udp_addr: tuple[Any, Any] | None = None
 
         self.rotation = 0
 
@@ -73,6 +81,9 @@ class Player(SimulationObject, body.ConstantAccelerationBody):
             num_frags=self.num_frags,
             color=self.color,
         )
+
+    def set_udp(self, udp_addr: tuple[Any, Any]) -> None:
+        self.udp_addr = udp_addr
 
     def update(self, input_message: PlayerStateMessage) -> None:
         self.movement_request = pygame.math.Vector2(input_message.delta_position)

--- a/simulation_object/player.py
+++ b/simulation_object/player.py
@@ -83,7 +83,8 @@ class Player(SimulationObject, body.ConstantAccelerationBody):
         )
 
     def set_udp(self, udp_addr: tuple[Any, Any]) -> None:
-        self.udp_addr = udp_addr
+        if self.udp_addr is None:
+            self.udp_addr = udp_addr
 
     def update(self, input_message: PlayerStateMessage) -> None:
         self.movement_request = pygame.math.Vector2(input_message.delta_position)


### PR DESCRIPTION
I'd suggest reading the commit message for 850a51ca81ac19fcd4691f4683dc3c715192b576, and it would be great if someone could test this on Windows or MacOS, but these changes seem to be working for me. Also, since there's no persistent connection for each client with UDP, we only have a single thread listening to network messages. This may have a performance impact, but I don't think there's anything we can do about that, unless we want to get fancy by load balancing the clients over multiple ports on the server, but that's a lot of complexity that we probably shouldn't add unless there's a real performance bottleneck.